### PR TITLE
Fix immediate website update reflection

### DIFF
--- a/app/administrator/page.tsx
+++ b/app/administrator/page.tsx
@@ -1079,7 +1079,13 @@ export default function AdministratorPage() {
       setIsLoading(true)
       const response = await fetch("/api/save-admin-data", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        cache: 'no-store',
+        headers: { 
+          "Content-Type": "application/json",
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        },
         body: JSON.stringify({
           enginePackages,
           hullColors,
@@ -1116,7 +1122,13 @@ export default function AdministratorPage() {
           try {
             const response = await fetch("/api/marketing-content", {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              cache: 'no-store',
+              headers: { 
+                "Content-Type": "application/json",
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'Pragma': 'no-cache',
+                'Expires': '0'
+              },
               body: JSON.stringify({
                 ...content,
                 title_en: content.title_en?.trim() || content.title_pt?.trim() || "",
@@ -1148,7 +1160,13 @@ export default function AdministratorPage() {
           try {
             await fetch("/api/marketing-manuals", {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              cache: 'no-store',
+              headers: { 
+                "Content-Type": "application/json",
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'Pragma': 'no-cache',
+                'Expires': '0'
+              },
               body: JSON.stringify(manual),
             })
           } catch (error) {
@@ -1165,7 +1183,13 @@ export default function AdministratorPage() {
           try {
             await fetch("/api/marketing-warranties", {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              cache: 'no-store',
+              headers: { 
+                "Content-Type": "application/json",
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'Pragma': 'no-cache',
+                'Expires': '0'
+              },
               body: JSON.stringify(warranty),
             })
           } catch (error) {
@@ -1182,7 +1206,13 @@ export default function AdministratorPage() {
           try {
             await fetch("/api/factory-production", {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              cache: 'no-store',
+              headers: { 
+                "Content-Type": "application/json",
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'Pragma': 'no-cache',
+                'Expires': '0'
+              },
               body: JSON.stringify(item),
             })
           } catch (error) {
@@ -1822,7 +1852,14 @@ export default function AdministratorPage() {
   const loadDataFromDatabase = async () => {
     try {
       setIsLoading(true)
-      const response = await fetch("/api/get-admin-data")
+      const response = await fetch("/api/get-admin-data", {
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
+      })
 
       if (!response.ok) {
         const fallbackText = await response.text()
@@ -1922,6 +1959,12 @@ export default function AdministratorPage() {
     try {
       const response = await fetch(`/api/marketing-content?id=${id}`, {
         method: "DELETE",
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
       })
 
       const result = await response.json()
@@ -1964,6 +2007,12 @@ export default function AdministratorPage() {
     try {
       const response = await fetch(`/api/marketing-manuals?id=${id}`, {
         method: "DELETE",
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
       })
 
       const result = await response.json()
@@ -2006,6 +2055,12 @@ export default function AdministratorPage() {
     try {
       const response = await fetch(`/api/marketing-warranties?id=${id}`, {
         method: "DELETE",
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
       })
 
       const result = await response.json()
@@ -2057,6 +2112,12 @@ export default function AdministratorPage() {
     try {
       const response = await fetch(`/api/factory-production?id=${id}`, {
         method: "DELETE",
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
       })
 
       const result = await response.json()
@@ -2078,7 +2139,14 @@ export default function AdministratorPage() {
 
   const refreshFactoryProduction = async () => {
     try {
-      const response = await fetch("/api/factory-production")
+      const response = await fetch("/api/factory-production", {
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
+      })
       const result = await response.json()
 
       if (result.success) {

--- a/app/api/factory-production/route.ts
+++ b/app/api/factory-production/route.ts
@@ -18,10 +18,24 @@ export async function GET() {
       return NextResponse.json({ success: false, error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true, data: data || [] })
+    const response = NextResponse.json({ success: true, data: data || [] })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error in factory production GET:", error)
-    return NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }
 
@@ -42,10 +56,24 @@ export async function POST(req: Request) {
       return NextResponse.json({ success: false, error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true, data })
+    const response = NextResponse.json({ success: true, data })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error in factory production POST:", error)
-    return NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }
 
@@ -66,9 +94,23 @@ export async function DELETE(req: Request) {
       return NextResponse.json({ success: false, error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true })
+    const response = NextResponse.json({ success: true })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error in factory production DELETE:", error)
-    return NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }

--- a/app/api/marketing-content/route.ts
+++ b/app/api/marketing-content/route.ts
@@ -117,10 +117,24 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: result.error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true, data: result.data?.[0] })
+    const response = NextResponse.json({ success: true, data: result.data?.[0] })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error in marketing content POST:", error)
-    return NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }
 
@@ -140,9 +154,23 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ success: false, error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true })
+    const response = NextResponse.json({ success: true })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error in marketing content DELETE:", error)
-    return NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }

--- a/app/api/marketing-manuals/route.ts
+++ b/app/api/marketing-manuals/route.ts
@@ -6,10 +6,24 @@ const db = new DatabaseService()
 export async function GET() {
   try {
     const manuals = await db.getMarketingManuals()
-    return NextResponse.json({ success: true, data: manuals })
+    const response = NextResponse.json({ success: true, data: manuals })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error fetching marketing manuals:", error)
-    return NextResponse.json({ success: false, error: "Failed to fetch marketing manuals" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Failed to fetch marketing manuals" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }
 
@@ -23,10 +37,24 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await db.saveMarketingManual(manual)
-    return NextResponse.json({ success: true, data: result })
+    const response = NextResponse.json({ success: true, data: result })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error saving marketing manual:", error)
-    return NextResponse.json({ success: false, error: "Failed to save marketing manual" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Failed to save marketing manual" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }
 
@@ -40,9 +68,23 @@ export async function DELETE(request: NextRequest) {
     }
 
     await db.deleteMarketingManual(Number.parseInt(id))
-    return NextResponse.json({ success: true })
+    const response = NextResponse.json({ success: true })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error deleting marketing manual:", error)
-    return NextResponse.json({ success: false, error: "Failed to delete marketing manual" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Failed to delete marketing manual" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }

--- a/app/api/marketing-warranties/route.ts
+++ b/app/api/marketing-warranties/route.ts
@@ -6,13 +6,27 @@ export async function GET() {
     const dbService = new DatabaseService()
     const warranties = await dbService.getMarketingWarranties()
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       success: true,
       data: warranties,
     })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error fetching marketing warranties:", error)
-    return NextResponse.json({ success: false, error: "Failed to fetch warranties" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Failed to fetch warranties" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }
 
@@ -22,13 +36,27 @@ export async function POST(request: NextRequest) {
     const dbService = new DatabaseService()
     const savedWarranty = await dbService.saveMarketingWarranty(warranty)
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       success: true,
       data: savedWarranty,
     })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error saving marketing warranty:", error)
-    return NextResponse.json({ success: false, error: "Failed to save warranty" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Failed to save warranty" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }
 
@@ -44,12 +72,26 @@ export async function DELETE(request: NextRequest) {
     const dbService = new DatabaseService()
     await dbService.deleteMarketingWarranty(Number.parseInt(id))
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       success: true,
       message: "Warranty deleted successfully",
     })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     console.error("Error deleting marketing warranty:", error)
-    return NextResponse.json({ success: false, error: "Failed to delete warranty" }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: "Failed to delete warranty" }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }

--- a/app/api/save-admin-data/route.ts
+++ b/app/api/save-admin-data/route.ts
@@ -19,10 +19,24 @@ export async function POST(req: Request) {
       await Promise.all(promises)
     }
 
-    return NextResponse.json({ success: true })
+    const response = NextResponse.json({ success: true })
+    
+    // Add no-cache headers to ensure fresh data
+    response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error"
     console.error("Save admin data error:", errorMessage)
-    return NextResponse.json({ success: false, error: errorMessage }, { status: 500 })
+    const errorResponse = NextResponse.json({ success: false, error: errorMessage }, { status: 500 })
+    
+    // Add no-cache headers to error responses too
+    errorResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+    errorResponse.headers.set('Pragma', 'no-cache')
+    errorResponse.headers.set('Expires', '0')
+    
+    return errorResponse
   }
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,32 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  // Disable cache in development to prevent stale data issues
+  experimental: {
+    serverComponentsExternalPackages: []
+  },
+  // Add headers to prevent caching
+  async headers() {
+    return [
+      {
+        source: '/api/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, must-revalidate',
+          },
+          {
+            key: 'Pragma',
+            value: 'no-cache',
+          },
+          {
+            key: 'Expires',
+            value: '0',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Disable caching for admin panel data to ensure immediate visibility of changes.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, modifications made in the admin panel (e.g., Engine Packages, Marketing Content) were not reflected until a Vercel redeploy. This was due to stale data caused by browser and Next.js caching. This PR adds `no-cache` headers to relevant API endpoints and frontend fetch requests, and configures Next.js to prevent caching of API responses, ensuring real-time updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee6325a1-0c05-479e-b52b-5cdd03e82efe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee6325a1-0c05-479e-b52b-5cdd03e82efe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>